### PR TITLE
Support for email attachments in multisite

### DIFF
--- a/functions/application-form.php
+++ b/functions/application-form.php
@@ -355,7 +355,7 @@ function wpbb_application_processing() {
 		}
 		
 		/* set attachments - the cv */
-		$wpbb_attachments = array( WP_CONTENT_DIR . '/uploads' . $wpbb_wp_upload_dir[ 'subdir' ] . '/' . basename( $wpbb_moved_file[ 'file' ] ) );
+		$wpbb_attachments = array( $wpbb_wp_upload_dir[ 'path' ] . '/' . basename( $wpbb_moved_file[ 'file' ] ) );
 		
 		/* send the mail */
 		$wpbb_send_email = wp_mail(


### PR DESCRIPTION
This fix allows WP Broadbean to attach an uploaded CV to the application/contact email when WordPress is using multisite and the site being viewed is not the default site. Without this fix, the CV seems to get attached only when the file is uploaded for the first time. Subsequent uploads of the same file (or another file with the same name) results in the CV not getting attached.