### PR TITLE
Add new filter ‘wpbb_application_form_no_form_error’

### DIFF
--- a/functions/application-form.php
+++ b/functions/application-form.php
@@ -105,8 +105,11 @@ function wpbb_application_form( $content ) {
 	/* no job ref was passed in the query string */	
 	} else {
 		
-		/* set an output message rather than the form */
-		$form = '<p class="message error">Error: No job reference detected!</p>';
+		
+		$form = apply_filters(
+			'wpbb_application_form_no_form_error',
+			'<p class="message error">Error: No job reference detected!</p>'
+		);
 		
 	}
 	


### PR DESCRIPTION
Allows no form error message to be customised/removed if application form page ID not set. Create function in theme functions file like this:

add_filter('wpbb_application_form_no_form_error', 'my_wpbb_filter_form_error' );
function wpbb_application_form_no_form_error() {

	return '<p class="message error">Error: My custom form error message!</p>';

}